### PR TITLE
fix: remove the duplicate '.' in the prefix url

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -100,7 +100,7 @@ const VEFORGE_PREFIXES = {
 }
 
 export function getEtherscanLink(networkId, data, type) {
-  const prefix = `https://${VEFORGE_PREFIXES[networkId] || VEFORGE_PREFIXES[1]}.vechain.org`
+  const prefix = `https://${VEFORGE_PREFIXES[networkId] || VEFORGE_PREFIXES[1]}vechain.org`
 
   switch (type) {
     case 'transaction': {


### PR DESCRIPTION
This fixes issue #25 

as the '.' is already present in the VEFORGE_PREFIXES it doesn't need to be repeated.